### PR TITLE
OAS-4313 | Convert Cause from global variable to function, so it can't be overwritten

### DIFF
--- a/common/v1/errors.go
+++ b/common/v1/errors.go
@@ -36,7 +36,7 @@ import (
 type CauseFunc = func(error) error
 
 // Cause is the cause function used by the error helpers in this module.
-var Cause = func(err error) error {
+func Cause(err error) error {
 	for err != nil {
 		if s, ok := status.FromError(err); ok {
 			return s.Err()


### PR DESCRIPTION
**WARNING:** after make update-modules in project depending on API-s you may need to remove (pkg|internal)/service/errros.go file which was overwriting this Cause global variable
Example: 
```
--> linux/amd64 error: exit status 2
Stderr: # github.com/arangodb-managed/rmd/internal/service
internal/service/errors.go:23:15: cannot assign to "github.com/arangodb-managed/apis/common/v1".Cause

--> linux/arm64 error: exit status 2
Stderr: # github.com/arangodb-managed/rmd/internal/service
internal/service/errors.go:23:15: cannot assign to "github.com/arangodb-managed/apis/common/v1".Cause

--> darwin/amd64 error: exit status 2
Stderr: # github.com/arangodb-managed/rmd/internal/service
internal/service/errors.go:23:15: cannot assign to "github.com/arangodb-managed/apis/common/v1".Cause

make: *** [Makefile:14: binaries] Error 1
```