### PR TITLE
OAS-9093 | Mark the public API calls (and migration agent permissions) deprecated (quick fix)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19964,7 +19964,8 @@ if project_id is not specified
                 <td><a href="#arangodb.cloud.replication.v1.DeploymentReplication">DeploymentReplication</a></td>
                 <td><p>Get an existing DeploymentReplication using its deployment ID
 Required permissions:
-- replication.deploymentreplication.get</p></td>
+- replication.deploymentreplication.get
+[Deprecated] This method shouldn&#39;t be used anymore, the permission is removed from the system already to prevent usage.</p></td>
               </tr>
             
               <tr>
@@ -19974,7 +19975,8 @@ Required permissions:
                 <td><p>Update an existing DeploymentReplication spec. If does not exist, this will create a new one.
 This call expects the complete entity with the updated fields.
 Required permissions:
-- replication.deploymentreplication.update</p></td>
+- replication.deploymentreplication.update
+[Deprecated] This method shouldn&#39;t be used anymore, the permission is removed from the system already to prevent usage.</p></td>
               </tr>
             
               <tr>

--- a/replication/v1/permissions.go
+++ b/replication/v1/permissions.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2020-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2024 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,12 +31,15 @@ const (
 	// Deployment replication permissions
 
 	// PermissionGetDeploymentReplication is needed to get a DeploymentReplication for a given Deployment
+	// [Deprecated] Deployment replication shouldn't be used anymore, the permission is removed from the system already to prevent usage.
 	PermissionGetDeploymentReplication = "replication.deploymentreplication.get"
 
 	// PermissionUpdateDeploymentReplication is needed to update / create a DeploymentReplication
+	// [Deprecated] Deployment replication shouldn't be used anymore, the permission is removed from the system already to prevent usage.
 	PermissionUpdateDeploymentReplication = "replication.deploymentreplication.update"
 
 	// PermissionUpgradeConnectionToForwarder is needed to start streaming connection via migration-forwarder
+	// [Deprecated] Deployment replication shouldn't be used anymore, the permission is removed from the system already to prevent usage.
 	PermissionUpgradeConnectionToForwarder = "replication.migration-forwarder.upgrade-connection"
 )
 

--- a/replication/v1/replication.pb.go
+++ b/replication/v1/replication.pb.go
@@ -774,11 +774,13 @@ type ReplicationServiceClient interface {
 	// Get an existing DeploymentReplication using its deployment ID
 	// Required permissions:
 	// - replication.deploymentreplication.get
+	// [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
 	GetDeploymentReplication(ctx context.Context, in *v1.IDOptions, opts ...grpc.CallOption) (*DeploymentReplication, error)
 	// Update an existing DeploymentReplication spec. If does not exist, this will create a new one.
 	// This call expects the complete entity with the updated fields.
 	// Required permissions:
 	// - replication.deploymentreplication.update
+	// [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
 	UpdateDeploymentReplication(ctx context.Context, in *DeploymentReplication, opts ...grpc.CallOption) (*DeploymentReplication, error)
 	// Create a new deployment migration.
 	// Note: currently migration is supported only for Deployments with 'free' model.
@@ -892,11 +894,13 @@ type ReplicationServiceServer interface {
 	// Get an existing DeploymentReplication using its deployment ID
 	// Required permissions:
 	// - replication.deploymentreplication.get
+	// [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
 	GetDeploymentReplication(context.Context, *v1.IDOptions) (*DeploymentReplication, error)
 	// Update an existing DeploymentReplication spec. If does not exist, this will create a new one.
 	// This call expects the complete entity with the updated fields.
 	// Required permissions:
 	// - replication.deploymentreplication.update
+	// [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
 	UpdateDeploymentReplication(context.Context, *DeploymentReplication) (*DeploymentReplication, error)
 	// Create a new deployment migration.
 	// Note: currently migration is supported only for Deployments with 'free' model.

--- a/replication/v1/replication.proto
+++ b/replication/v1/replication.proto
@@ -1,7 +1,7 @@
 // 
 // DISCLAIMER
 // 
-// Copyright 2020-2023 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2024 ArangoDB GmbH, Cologne, Germany
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ service ReplicationService {
     // Get an existing DeploymentReplication using its deployment ID
     // Required permissions:
     // - replication.deploymentreplication.get
+    // [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
     rpc GetDeploymentReplication(common.v1.IDOptions) returns (DeploymentReplication) {
         option (google.api.http) = {
             get: "/api/replication/v1/deployment/{id}/replication"
@@ -76,6 +77,7 @@ service ReplicationService {
     // This call expects the complete entity with the updated fields.
     // Required permissions:
     // - replication.deploymentreplication.update
+    // [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
     rpc UpdateDeploymentReplication(DeploymentReplication) returns (DeploymentReplication) {
         option (google.api.http) = {
             put: "/api/replication/v1/deployment/{deployment_id}/replication"

--- a/replication/v1/version.go
+++ b/replication/v1/version.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2020-2023 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2024 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,5 +28,5 @@ const (
 	// APIMinorVersion contains minor version of this API
 	APIMinorVersion = 3
 	// APIPatchVersion contains patch version of this API
-	APIPatchVersion = 0
+	APIPatchVersion = 1
 )

--- a/typescript/replication/v1/replication.ts
+++ b/typescript/replication/v1/replication.ts
@@ -232,12 +232,14 @@ export interface IReplicationService {
   // Get an existing DeploymentReplication using its deployment ID
   // Required permissions:
   // - replication.deploymentreplication.get
+  // [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
   GetDeploymentReplication: (req: arangodb_cloud_common_v1_IDOptions) => Promise<DeploymentReplication>;
   
   // Update an existing DeploymentReplication spec. If does not exist, this will create a new one.
   // This call expects the complete entity with the updated fields.
   // Required permissions:
   // - replication.deploymentreplication.update
+  // [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
   UpdateDeploymentReplication: (req: DeploymentReplication) => Promise<DeploymentReplication>;
   
   // Create a new deployment migration.
@@ -292,6 +294,7 @@ export class ReplicationService implements IReplicationService {
   // Get an existing DeploymentReplication using its deployment ID
   // Required permissions:
   // - replication.deploymentreplication.get
+  // [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
   async GetDeploymentReplication(req: arangodb_cloud_common_v1_IDOptions): Promise<DeploymentReplication> {
     const path = `/api/replication/v1/deployment/${encodeURIComponent(req.id || '')}/replication`;
     const url = path + api.queryString(req, [`id`]);
@@ -302,6 +305,7 @@ export class ReplicationService implements IReplicationService {
   // This call expects the complete entity with the updated fields.
   // Required permissions:
   // - replication.deploymentreplication.update
+  // [Deprecated] This method shouldn't be used anymore, the permission is removed from the system already to prevent usage.
   async UpdateDeploymentReplication(req: DeploymentReplication): Promise<DeploymentReplication> {
     const url = `/api/replication/v1/deployment/${encodeURIComponent(req.deployment_id || '')}/replication`;
     return api.put(url, req);


### PR DESCRIPTION
The real removal will follow in a BREAKING PR later.